### PR TITLE
refactor(core): Move set freeday colors to core

### DIFF
--- a/addons/sourcemod/scripting/jwp_core.sp
+++ b/addons/sourcemod/scripting/jwp_core.sp
@@ -49,7 +49,11 @@ ConVar	g_CvarChooseMode,
 		g_CvarVoteTime,
 		g_CvarDisableAntiFlood,
 		g_CvarAutoUpdate,
-		g_CvarMenuAutoOpen;
+		g_CvarMenuAutoOpen,
+		g_CvarFreeDayR,
+		g_CvarFreeDayG,
+		g_CvarFreeDayB,
+		g_CvarFreeDayA;
 
 Handle g_hChooseTimer;
 
@@ -78,7 +82,11 @@ public void OnPluginStart()
 	g_CvarDisableAntiFlood = CreateConVar("jwp_disable_antiflood", "0", "Disable menu protection from spam-clicking", FCVAR_SPONLY, true, 0.0, true, 1.0);
 	g_CvarAutoUpdate = CreateConVar("jwp_autoupdate", "1", "Enable (1) or disable (0) auto update. Need Updater!", FCVAR_SPONLY, true, 0.0, true, 1.0);
 	g_CvarMenuAutoOpen = CreateConVar("jwp_menuautoopen", "1", "Enable (1) or disable (0) warden menu auto open after warden chosen!", FCVAR_SPONLY, true, 0.0, true, 1.0);
-	
+	g_CvarFreeDayR = CreateConVar("jwp_freeday_r", "0", "Красный оттенок заключенного, который получил freeday (rgba)", _, true, 0.0, true, 255.0);
+	g_CvarFreeDayG = CreateConVar("jwp_freeday_g", "255", "Зеленый оттенок заключенного, который получил freeday (rgba)", _, true, 0.0, true, 255.0);
+	g_CvarFreeDayB = CreateConVar("jwp_freeday_b", "0", "Синий оттенок заключенного, который получил freeday (rgba)", _, true, 0.0, true, 255.0);
+	g_CvarFreeDayA = CreateConVar("jwp_freeday_a", "255", "Прозрачность заключенного, который получил freeday (rgba)", _, true, 0.0, true, 255.0);
+
 	RegConsoleCmd("sm_com", Command_BecomeWarden, "Warden menu");
 	RegConsoleCmd("sm_w", Command_BecomeWarden, "Warden menu");
 	RegConsoleCmd("sm_warden", Command_BecomeWarden, "Warden menu");
@@ -516,6 +524,15 @@ bool PrisonerSetFreeday(int client, bool state = true)
 	if (client <= MaxClients && CheckClient(client))
 	{
 		g_ClientAPIInfo[client].has_freeday = state;
+
+		SetEntityRenderMode(client, RENDER_TRANSCOLOR);
+		SetEntityRenderColor(client,
+			(state) ? g_CvarFreeDayR.IntValue : 255,
+			(state) ? g_CvarFreeDayG.IntValue : 255,
+			(state) ? g_CvarFreeDayB.IntValue : 255,
+			(state) ? g_CvarFreeDayA.IntValue : 255
+		);
+
 		return true;
 	}
 	return false;

--- a/addons/sourcemod/scripting/jwp_freeday.sp
+++ b/addons/sourcemod/scripting/jwp_freeday.sp
@@ -9,11 +9,6 @@
 #define FDGIVE "freeday_give"
 #define FDTAKE "freeday_take"
 
-ConVar	g_Cvar_r,
-		g_Cvar_g,
-		g_Cvar_b,
-		g_Cvar_a;
-
 public Plugin myinfo = 
 {
 	name = "[JWP] Freeday",
@@ -25,11 +20,6 @@ public Plugin myinfo =
 
 public void OnPluginStart()
 {
-	g_Cvar_r = CreateConVar("jwp_freeday_r", "0", "Красный оттенок заключенного, который получил freeday (rgba)", _, true, 0.0, true, 255.0);
-	g_Cvar_g = CreateConVar("jwp_freeday_g", "255", "Зеленый оттенок заключенного, который получил freeday (rgba)", _, true, 0.0, true, 255.0);
-	g_Cvar_b = CreateConVar("jwp_freeday_b", "0", "Синий оттенок заключенного, который получил freeday (rgba)", _, true, 0.0, true, 255.0);
-	g_Cvar_a = CreateConVar("jwp_freeday_a", "255", "Прозрачность заключенного, который получил freeday (rgba)", _, true, 0.0, true, 255.0);
-	
 	if (JWP_IsStarted()) JWP_Started();
 	
 	AutoExecConfig(true, "freeday", "jwp");
@@ -145,12 +135,6 @@ public int PList_Callback(Menu menu, MenuAction action, int client, int slot)
 					state = !state;
 					
 					JWP_PrisonerSetFreeday(target, state);
-					
-					SetEntityRenderMode(target, RENDER_TRANSCOLOR);
-					SetEntityRenderColor(target, (state) ? g_Cvar_r.IntValue : 255,
-												(state) ? g_Cvar_g.IntValue : 255,
-												(state) ? g_Cvar_b.IntValue : 255,
-												(state) ? g_Cvar_a.IntValue : 255);
 					JWP_ActionMsgAll("%T", (state) ? "Freeday_ActionMessage_Gived" : "Freeday_ActionMessage_Taken", LANG_SERVER, client, target);
 				}
 				menu.RemoveItem(slot);


### PR DESCRIPTION
Думаю правильнее избавиться от установки цветов и convarов FreeDay'а в отдельном плагине, когда в ядре у нас есть основная функция для установки FreeDay.
С текущей реализацией, если мы хотим выдавать игрокам FreeDay, то нам надо тянуть convarы с собой, что не очень то круто.

У меня были кейсы:
1) Плагин с системой запросами/отказами. Есть опция выдачи FreeDay, и чтобы ее выдать, мне приходиться тянуть цвета.
2) Плагин с автовыдачей фд, тоже самое, приходиться тянуть цвета.
